### PR TITLE
Use newer pysaml2 compatible with Python 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 django>=2.2
 django-allauth>=0.43.0
-pysaml2==5.0.0
+pysaml2>=7.1.0


### PR DESCRIPTION
With Python 3.10 and pysaml2==5.0.0 an AttributeError occurs:

```python
...
  File "/home/<...>/lib/python3.10/site-packages/saml2/saml.py", line 90, in <module>
    _b64_decode_fn = getattr(base64, 'decodebytes', base64.decodestring)
AttributeError: module 'base64' has no attribute 'decodestring'
```

This goes away when using a newer version of pysaml2, e.g. the current version 7.1.2.